### PR TITLE
docs(examples): update install-cli to command usage

### DIFF
--- a/src/examples/install-cli.yml
+++ b/src/examples/install-cli.yml
@@ -6,10 +6,11 @@ description: >
 usage:
   version: 2.1
   orbs:
-    lacework: lacework/lacework@1.2.3
+    lacework: lacework/lacework@x.y
   jobs:
     list-events-test:
-      executor: orb-tools/ubuntu
+      docker:
+        - image: cimg/base:stable
       steps:
         - checkout
         - lacework/install-cli

--- a/src/examples/install-cli.yml
+++ b/src/examples/install-cli.yml
@@ -1,10 +1,16 @@
 description: >
-  This example shows how to install the lacework-cli
+  This example shows how to install the lacework-cli.
+
+  For more information about the Lacework CLI visit:
+    - https://github.com/lacework/go-sdk/wiki/CLI-Documentation
 usage:
   version: 2.1
   orbs:
     lacework: lacework/lacework@1.2.3
-  workflows:
-    prepare_my_app:
-      jobs:
+  jobs:
+    list-events-test:
+      executor: orb-tools/ubuntu
+      steps:
+        - checkout
         - lacework/install-cli
+        - run: lacework events list

--- a/src/examples/vuln-scan.yml
+++ b/src/examples/vuln-scan.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    lacework: lacework/lacework@1.2.3
+    lacework: lacework/lacework@x.y
   workflows:
     scan_my_container:
       jobs:


### PR DESCRIPTION
The `install-cli` example should be a command usage rather than job usage.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>