### PR TITLE
chore(vuln-scan-run) Update vuln-scan-run command

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.2
 
 description: >
   Use the Lacework Orb to add security into your CI/CD pipeline.

--- a/src/commands/vuln-scan-run.yml
+++ b/src/commands/vuln-scan-run.yml
@@ -36,7 +36,7 @@ steps:
           TAG_OR_DIGEST=<<parameters.digest>>
         fi
 
-        lacework vulnerability scan run <<parameters.registry>> <<parameters.repository>> $TAG_OR_DIGEST \
+        lacework vulnerability container scan <<parameters.registry>> <<parameters.repository>> $TAG_OR_DIGEST \
             --account ${<< parameters.account >>} \
             --api_key ${<< parameters.api-key >>} \
             --api_secret ${<< parameters.api-secret >>} \


### PR DESCRIPTION
Updating vuln-scan-run command to adhere to changes in Lacework CLI v.0.2.0 which uses the `lacework vulnerability container scan ` command.

Signed-off-by: Scott Ford <scott.ford@lacework.net>