### PR TITLE
refactor(vuln-scan-run) Update vuln-scan-run command [semver:patch]

### DIFF
--- a/src/commands/vuln-scan-run.yml
+++ b/src/commands/vuln-scan-run.yml
@@ -36,7 +36,7 @@ steps:
           TAG_OR_DIGEST=<<parameters.digest>>
         fi
 
-        lacework vulnerability scan run <<parameters.registry>> <<parameters.repository>> $TAG_OR_DIGEST \
+        lacework vulnerability container scan <<parameters.registry>> <<parameters.repository>> $TAG_OR_DIGEST \
             --account ${<< parameters.account >>} \
             --api_key ${<< parameters.api-key >>} \
             --api_secret ${<< parameters.api-secret >>} \


### PR DESCRIPTION
Refactoring `vuln-scan-run.yml` to use the latest version of the[ Lacework CLI v0.2.0](https://github.com/lacework/go-sdk/releases/tag/v0.2.0) `lacework vulnerability container` command


Signed-off-by: Scott Ford <scott.ford@lacework.net>