### PR TITLE
Release new details and html parameters for ctr-vuln-scan job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,15 @@ jobs:
       - lacework/ctr-vuln-scan:
           registry: "index.docker.io"
           repository: "lacework/lacework-cli"
+          details: on
+          html: yes
+      - run:
+          command: |
+            mkdir  circleci-artifacts/
+            mv lacework-lacework-cli* circleci-artifacts/
+
+      - store_artifacts:
+          path: circleci-artifacts
 
   integration-test-scan-pkg-manifest:
     executor: lacework/default

--- a/src/commands/ctr-vuln-scan.yml
+++ b/src/commands/ctr-vuln-scan.yml
@@ -11,6 +11,14 @@ parameters:
     description: The image tag to scan
     type: string
     default: latest
+  details:
+    description: Show more details of the vulnerability scan results
+    type: boolean
+    default: false
+  html:
+    description: Generate a vulnerability assessment in HTML format
+    type: boolean
+    default: false
   digest:
     description: An image digest to scan (format sha256:1ee...1d3b)
     type: string
@@ -40,4 +48,5 @@ steps:
             --account ${<< parameters.account >>} \
             --api_key ${<< parameters.api-key >>} \
             --api_secret ${<< parameters.api-secret >>} \
-            --poll --noninteractive
+            --poll <<# parameters.html >> --html <</ parameters.html >> \
+            --noninteractive <<# parameters.details >> --details <</ parameters.details >>


### PR DESCRIPTION
The new parameter are rendered correctly:
![image](https://user-images.githubusercontent.com/5712253/99097362-c24ac680-2594-11eb-88ac-a448a3baa5b2.png)
