### PR TITLE
Release job/ctr-vuln-scan feature for HTML generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,14 @@ jobs:
           html: yes
       - run:
           command: |
-            mkdir  circleci-artifacts/
-            mv lacework-lacework-cli* circleci-artifacts/
+            mkdir  lacework-artifacts/
+
+            if [ `ls -1 lacework-lacework-cli* 2>/dev/null | wc -l ` -gt 0 ]; then
+                mv lacework-lacework-cli* lacework-artifacts/
+            fi
 
       - store_artifacts:
-          path: circleci-artifacts
+          path: lacework-artifacts
 
   integration-test-scan-pkg-manifest:
     executor: lacework/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - lacework/ctr-vuln-scan:
           registry: "index.docker.io"
           repository: "lacework/lacework-cli"
+          tag: "debian-10"
           details: on
           html: yes
       - run:
@@ -106,6 +107,11 @@ workflows:
       - integration-test-install-cli
       - integration-test-ctr-vuln-scan
       - integration-test-scan-pkg-manifest
+      - lacework/ctr-vuln-scan:
+          registry: "index.docker.io"
+          repository: "lacework/lacework-cli"
+          tag: "ubuntu-1804"
+          html: true
 
       # publish a semver version of the orb. relies on the commit
       # subject containing the text "[semver:patch|minor|major|skip]"

--- a/src/examples/ctr-vuln-scan-html-artifact.yml
+++ b/src/examples/ctr-vuln-scan-html-artifact.yml
@@ -1,0 +1,15 @@
+description: >
+  This example runs a container vulnerability scan using the ctr-vuln-scan job,
+  it will generate the container vulnerability assessment in HTML format and
+  store the artifact automatically.
+usage:
+  version: 2.1
+  orbs:
+    lacework: lacework/lacework@x.y
+  workflows:
+    scan_container_and_generate_html_artifact:
+      jobs:
+        - lacework/ctr-vuln-scan:
+            registry: "index.docker.io"
+            repository: "lacework/lacework-cli"
+            html: true

--- a/src/jobs/ctr-vuln-scan.yml
+++ b/src/jobs/ctr-vuln-scan.yml
@@ -16,9 +16,33 @@ parameters:
     description: An image digest to scan (format sha256:1ee...1d3b)
     type: string
     default: ""
+  html:
+    description: Generate a vulnerability assessment in HTML format
+    type: boolean
+    default: false
+  details:
+    description: Show more details of the vulnerability scan results
+    type: boolean
+    default: false
 steps:
   - ctr-vuln-scan:
       registry: << parameters.registry >>
       repository: << parameters.repository >>
       digest: << parameters.digest >>
       tag: << parameters.tag >>
+      html: << parameters.html >>
+      details: << parameters.details >>
+  - when:
+      condition: <<parameters.html>>
+      steps:
+        - run:
+            command: |
+              _repo="<<parameters.repository>>"
+              _repo_format="${_repo//\//-}"
+
+              mkdir lacework-artifacts/
+              if [ `ls -1 "${_repo//\//-}"* 2>/dev/null | wc -l ` -gt 0 ]; then
+                  mv "${_repo//\//-}*" lacework-artifacts/
+              fi
+        - store_artifacts:
+            path: lacework-artifacts

--- a/src/jobs/ctr-vuln-scan.yml
+++ b/src/jobs/ctr-vuln-scan.yml
@@ -42,7 +42,7 @@ steps:
 
               mkdir lacework-artifacts/
               if [ `ls -1 "${_repo//\//-}"* 2>/dev/null | wc -l ` -gt 0 ]; then
-                  mv "${_repo//\//-}*" lacework-artifacts/
+                  mv "${_repo//\//-}"* lacework-artifacts/
               fi
         - store_artifacts:
             path: lacework-artifacts


### PR DESCRIPTION
This change adds a feature to the container vulnerability scan (job/ctr-vuln-scan) where
it generates the container vulnerability assessment in HTML format and stores the artifact automatically.

Here is an example:
``` 
usage:
  version: 2.1
  orbs:
    lacework: lacework/lacework@x.y
  workflows:
    scan_container_and_generate_html_artifact:
      jobs:
        - lacework/ctr-vuln-scan:
            registry: "index.docker.io"
            repository: "lacework/lacework-cli"
            html: true
```

## Job Output

<img width="1573" alt="Screen Shot 2020-11-20 at 9 57 32 AM" src="https://user-images.githubusercontent.com/5712253/99780538-df6f2000-2ad3-11eb-89d0-cb6d53b8fda5.png">

## Then click on "ARTIFACTS"

<img width="1904" alt="Screen Shot 2020-11-20 at 9 55 46 AM" src="https://user-images.githubusercontent.com/5712253/99780678-09c0dd80-2ad4-11eb-9d68-20f4d5573652.png">

## Finally, click on the generated HTML file
<img width="1904" alt="Screen Shot 2020-11-20 at 9 55 51 AM" src="https://user-images.githubusercontent.com/5712253/99780728-1c3b1700-2ad4-11eb-8171-5bc586d9cad7.png">

