### PR TITLE
feat: add policy parameter to evaluate command [semver:minor] (#34)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       - lacework/ctr-vuln-scan:
           registry: "index.docker.io"
           repository: "lacework/lacework-cli"
-          tag: "debian-10"
+          tag: "amazonlinux-2"
           fail_on_severity: "critical"
 
   integration-test-scan-pkg-manifest:

--- a/src/commands/inline-scanner-evaluate.yml
+++ b/src/commands/inline-scanner-evaluate.yml
@@ -45,6 +45,10 @@ parameters:
     description: Environment tags from CI execution, e.g. --tags component=frontend
     default: ""
     type: string
+  policy:
+    description: Evaluate policies configured in the Lacework platform
+    default: false
+    type: boolean
   critical_violation_exit_code:
     description: Exit code for critical policy violation (default -1)
     type: integer
@@ -82,7 +86,7 @@ steps:
           exit 1
         fi
 
-        lw-scanner evaluate <<parameters.image_name>> $TAG_OR_DIGEST  \
+        lw-scanner image evaluate <<parameters.image_name>> $TAG_OR_DIGEST  \
         <<# parameters.fixable >> --fixable <</ parameters.fixable >> \
         <<# parameters.scan_library_packages >> --scan-library-packages <</ parameters.scan_library_packages >> \
         <<# parameters.save >> --save <</ parameters.save >> \
@@ -91,6 +95,7 @@ steps:
         <<# parameters.build_id >> --build-id << parameters.build_id >> <</ parameters.build_id >> \
         <<# parameters.build_plan >> --build-plan << parameters.build_plan >> <</ parameters.build_plan >> \
         <<# parameters.html >> --html <</ parameters.html >> \
+        <<# parameters.policy >> --policy <</ parameters.policy >> \
         <<# parameters.critical_violation_exit_code >> --critical-violation-exit-code << parameters.critical_violation_exit_code >> <</ parameters.critical_violation_exit_code >> \
         <<# parameters.high_violation_exit_code >> --high-violation-exit-code << parameters.high_violation_exit_code >> <</ parameters.high_violation_exit_code >> \
         <<# parameters.medium_violation_exit_code >> --medium-violation-exit-code << parameters.medium_violation_exit_code >> <</ parameters.medium_violation_exit_code >> \

--- a/src/examples/install-cli.yml
+++ b/src/examples/install-cli.yml
@@ -2,7 +2,7 @@ description: >
   This example shows how to install the lacework-cli.
 
   For more information about the Lacework CLI visit:
-    - https://github.com/lacework/go-sdk/wiki/CLI-Documentation
+    - https://docs.lacework.com/cli
 usage:
   version: 2.1
   orbs:


### PR DESCRIPTION
* chore: update install-cli cmd to use 'main' branch (#28)

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

* chore: deprecate CLI Wiki (#33)

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

* feat: add policy parameter to evaluate command (#32)

Also changed the command to "image evaluate" to make it consistent with the documentation.

* ci: change image tag to fail-on-severity

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

Co-authored-by: Ross Macduff <77633997+ls-ross-macduff@users.noreply.github.com>